### PR TITLE
use internal mode when creating statefile fixes #4

### DIFF
--- a/lib/Monitoring/GLPlugin.pm
+++ b/lib/Monitoring/GLPlugin.pm
@@ -1205,7 +1205,7 @@ sub create_statefile {
   $extension =~ s/\*/_/g;
   $extension =~ s/\s/_/g;
   return sprintf "%s/%s%s", $self->statefilesdir(),
-      $self->clean_path($self->opts->mode), $self->clean_path(lc $extension);
+      $self->clean_path($self->mode), $self->clean_path(lc $extension);
 }
 
 sub clean_path {

--- a/lib/Monitoring/GLPlugin/SNMP/CSF.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/CSF.pm
@@ -18,15 +18,15 @@ sub create_statefile {
   if ($self->opts->snmpwalk && ! $self->opts->hostname) {
     return sprintf "%s/%s_%s%s", $self->statefilesdir(),
         'snmpwalk.file'.md5_hex($self->opts->snmpwalk),
-        $self->clean_path($self->opts->mode), $self->clean_path(lc $extension);
+        $self->clean_path($self->mode), $self->clean_path(lc $extension);
   } elsif ($self->opts->snmpwalk && $self->opts->hostname eq "walkhost") {
     return sprintf "%s/%s_%s%s", $self->statefilesdir(),
         'snmpwalk.file'.md5_hex($self->opts->snmpwalk),
-        $self->clean_path($self->opts->mode), $self->clean_path(lc $extension);
+        $self->clean_path($self->mode), $self->clean_path(lc $extension);
   } else {
     return sprintf "%s/%s_%s%s", $self->statefilesdir(),
         $self->opts->hostname,
-        $self->clean_path($self->opts->mode), $self->clean_path(lc $extension);
+        $self->clean_path($self->mode), $self->clean_path(lc $extension);
   }
 }
 


### PR DESCRIPTION
Do not use the external mode, otherwise InterfaceSubsystem will not work
when changing the internal mode during runtime.
