### PR TITLE
Allowing separate statefile for interfaces using snmpv3 context

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -1427,6 +1427,9 @@ sub create_interface_cache_file {
     $self->opts->override_opt('hostname',
         'snmpwalk.file'.md5_hex($self->opts->snmpwalk))
   }
+  if ($self->opts->contextname) {
+    $extension .= $self->opts->contextname . '_';
+  }
   if ($self->opts->community) { 
     $extension .= md5_hex($self->opts->community);
   }


### PR DESCRIPTION
This PR allows to use snmpv3 context, where the interface list differ between the different contexts (e.g. Checkpoint VSX). 
This solves https://github.com/lausser/check_nwc_health/issues/177 and https://github.com/lausser/check_nwc_health/issues/165