### PR TITLE
Add basic Huawei S series MIBs

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEICPUMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEICPUMIB.pm
@@ -1,0 +1,17 @@
+package Monitoring::GLPlugin::SNMP::MibsAndOids::HUAWEICPUMIB;
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::origin->{'HUAWEI-CPU-MIB'} = {
+  url => '',
+  name => 'HUAWEI-CPU-MIB',
+};
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'HUAWEI-CPU-MIB'} = {
+    hwCpuDevTable            => '1.3.6.1.4.1.2011.6.3.4',
+    hwCpuDevEntry            => '1.3.6.1.4.1.2011.6.3.4.1',
+    hwCpuDevIndex            => '1.3.6.1.4.1.2011.6.3.4.1.1',
+    hwCpuDevDuty             => '1.3.6.1.4.1.2011.6.3.4.1.2',
+};
+
+1;
+
+__END__

--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIENERGYMNGTMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIENERGYMNGTMIB.pm
@@ -1,0 +1,21 @@
+package Monitoring::GLPlugin::SNMP::MibsAndOids::HUAWEIENERGYMNGTMIB;
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::origin->{'HUAWEI-ENERGYMNGT-MIB'} = {
+  url => '',
+  name => 'HUAWEI-ENERGYMNGT-MIB',
+};
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'HUAWEI-ENERGYMNGT-MIB'} = {
+    hwPowerConsumptionTable  => '1.3.6.1.4.1.2011.6.157',
+    hwPowerConsumptionEntry  => '1.3.6.1.4.1.2011.6.157.1',
+    hwPowerConsumption       => '1.3.6.1.4.1.2011.6.157.1.1',
+    hwPowerStatPeriod        => '1.3.6.1.4.1.2011.6.157.1.2',
+
+    hwAveragePower           => '1.3.6.1.4.1.2011.6.157.1.3',
+    hwRatedPower             => '1.3.6.1.4.1.2011.6.157.1.4',
+    hwCurrentPower           => '1.3.6.1.4.1.2011.6.157.1.6',
+};
+
+1;
+
+__END__

--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIMEMORYMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIMEMORYMIB.pm
@@ -1,0 +1,18 @@
+package Monitoring::GLPlugin::SNMP::MibsAndOids::HUAWEIMEMORYMIB;
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::origin->{'HUAWEI-MEMORY-MIB'} = {
+  url => '',
+  name => 'HUAWEI-MEMORY-MIB',
+};
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'HUAWEI-MEMORY-MIB'} = {
+    hwMemoryDevTable            => '1.3.6.1.4.1.2011.6.3.5',
+    hwMemoryDevEntry            => '1.3.6.1.4.1.2011.6.3.5.1.1',
+    hwMemoryDevModuleIndex      => '1.3.6.1.4.1.2011.6.3.5.1.1.1',
+    hwMemoryDevSize             => '1.3.6.1.4.1.2011.6.3.5.1.1.2',
+    hwMemoryDevFree             => '1.3.6.1.4.1.2011.6.3.5.1.1.3',
+};
+
+1;
+
+__END__


### PR DESCRIPTION
Adds basic MIBs for Huawei S series networking switches, needed by their corresponding new checks in check_nwc_health. Please see the PR there for more details.