### PR TITLE
Document warningx/criticalx threshold string matching

### DIFF
--- a/lib/Monitoring/GLPlugin.pm
+++ b/lib/Monitoring/GLPlugin.pm
@@ -111,9 +111,9 @@ sub add_default_args {
   $self->add_arg(
       spec => 'warningx=s%',
       help => '--warningx
-   The extended warning thresholds
-   e.g. --warningx db_msdb_free_pct=6: to override the threshold for a
-   specific item ',
+   The extended warning thresholds - example uses:
+   Override a specific threshold:      --warningx db_msdb_free_pct=6
+   Override all thresholds that match: --warningx \'.*discards.*\'=100',
       required => 0,
   );
   $self->add_arg(


### PR DESCRIPTION
This feature isn't well-documented, so I have added an example.