### PR TITLE
DateAndTime - Fallback when datetime = 0

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/MIB2MIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/MIB2MIB.pm
@@ -97,6 +97,11 @@ $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{'MIB-2-MIB'} = {
       $year -= 1900;
       $month += 1;
     }
+    if ($year == 0 && $month == 0) {
+      $year = 1970;
+      $month = 1;
+      $day = 1;
+    }
     my $epoch = timegm($second, $minute, $hour, $day, $month-1, $year-1900);
     # 1992-5-26,13:30:15.0,-4:0 = Tuesday May 26, 1992 at 1:30:15 PM EDT
     # Eastern Daylight Time (EDT) is 4 hours behind Coordinated Universal Time (UTC)


### PR DESCRIPTION
Re-insert the fallback when the datetime value is 0 (year and month = 0)

The plugin fails with mode hardware-health on Juniper SRX due to value of OID jnxOperatingRestartTime (1.3.6.1.4.1.2636.3.1.13.1.19) equal to "0-0-0,0:0:0.0,.0:0". It fails within the subfunction DateAndTime because epoch cannot be created with year and month = 0.

Plugin output:
```
# 'check_nwc_health' '--community' 'community' '--hostname' 'ipaddress ' '--mode' 'hardware-health' 
Month '-1' out of range 0..11 at check_nwc_health line 5804.
```
snmpwalk:
```
# snmpwalk -v2c -c community ipaddress 1.3.6.1.4.1.2636.3.1.13.1.19
JUNIPER-MIB::jnxOperatingRestartTime.1.1.0.0 = STRING: 2019-10-30,13:51:40.0,+0:0
JUNIPER-MIB::jnxOperatingRestartTime.2.1.0.0 = STRING: 2019-10-30,13:51:40.0,+0:0
JUNIPER-MIB::jnxOperatingRestartTime.7.1.0.0 = STRING: 2019-10-30,13:56:36.0,+0:0
JUNIPER-MIB::jnxOperatingRestartTime.8.1.1.0 = STRING: 2019-10-30,13:56:37.0,+0:0
JUNIPER-MIB::jnxOperatingRestartTime.9.1.0.0 = STRING: 2019-10-30,13:51:40.0,+0:0
JUNIPER-MIB::jnxOperatingRestartTime.9.1.1.0 = STRING: 0-0-0,0:0:0.0,.0:0
```

The piece of code added in this pull request was removed by commit dcdb758