### PR TITLE
ignore endOfMibView when doing get_next_request, it does not give rel…

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -1459,6 +1459,14 @@ sub implements_mib {
     $traces = $Monitoring::GLPlugin::SNMP::session->get_next_request(%params);
     $Monitoring::GLPlugin::SNMP::session->timeout($timeout);
   }
+
+  # endOfMibView probably does not give much information here
+  foreach (keys %{$traces}) {
+    if (${$traces}{$_} eq 'endOfMibView') {
+      delete @{$traces}{$_};
+    }
+  }
+
   if ($traces && # must find oids following to the ident-oid
       ! exists $traces->{$Monitoring::GLPlugin::SNMP::MibsAndOids::mib_ids->{$mib}} && # must not be the ident-oid
       grep { # following oid is inside this tree


### PR DESCRIPTION
Because of $traces containing
```
{
  '1.3.6.1.4.1.705.1.0' => 'endOfMibView'
};
```
Enconnex AC6000 is wrongly expected to support the MIBs from MG-SNMP-UPS-MIB.

Signed-off-by: Jan Tlusty <j.tlusty@gmail.com>