### PR TITLE
Adding support for CISCO-ALARM-MIB

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+* 2021-03-19 3.3.3.4
+  bugfix in CISCO-ENTITY-SENSOR-MIB + ENTITY-SENSOR-MIB. Scale values correctly.
 * 2021-03-09 3.3.3.3
   bugfix in check_thresholds
 * 2021-03-08 3.3.3.2

--- a/lib/Monitoring/GLPlugin.pm
+++ b/lib/Monitoring/GLPlugin.pm
@@ -20,7 +20,7 @@ eval {
   $Data::Dumper::Sparseseen = 1;
 };
 our $AUTOLOAD;
-*VERSION = \'3.3.3.3';
+*VERSION = \'3.3.3.4';
 
 use constant { OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3 };
 

--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -1269,7 +1269,7 @@ sub bulk_baeh_reset {
   my ($self, $maxrepetitions) = @_;
   $self->reset_snmp_max_msg_size();
   $Monitoring::GLPlugin::SNMP::maxrepetitions =
-      $Monitoring::GLPlugin::SNMP::session->max_msg_size() * 0.017;
+      int($Monitoring::GLPlugin::SNMP::session->max_msg_size() * 0.017);
 }
 
 sub bulk_is_baeh {

--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -2609,19 +2609,23 @@ sub make_symbolic {
                     exists $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition} &&
                     ref($Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}) eq 'CODE') {
                   if ($parameters) {
-                    if (! exists $mo->{$parameters}) {
-                      # this happens if there are two isolated get_snmp_object calls, one for
-                      # cLHaPeerIpAddressType and one for cLHaPeerIpAddress where the latter needs
-                      # the symbolized value of the first. we are inside this index-loop because
-                      # both have this usual extra .0 although this is not a table row.
-                      # if this were a table row, $mo would know cLHaPeerIpAddressType.
-                      # there's a chance that $self got cLHaPeerIpAddressType in a previous call
-                      # to make_symbolic
-                      if (@{$indices} and scalar(@{$indices}) == 1 and ! $indices->[0]->[0]) {
-                        $mo->{$parameters} = $self->{$parameters};
+                    my @args = ($result->{$fulloid});
+                    foreach my $parameter (split(",", $parameters)) {
+                      if (! exists $mo->{$parameter}) {
+                        # this happens if there are two isolated get_snmp_object calls, one for
+                        # cLHaPeerIpAddressType and one for cLHaPeerIpAddress where the latter needs
+                        # the symbolized value of the first. we are inside this index-loop because
+                        # both have this usual extra .0 although this is not a table row.
+                        # if this were a table row, $mo would know cLHaPeerIpAddressType.
+                        # there's a chance that $self got cLHaPeerIpAddressType in a previous call
+                        # to make_symbolic
+                        if (@{$indices} and scalar(@{$indices}) == 1 and ! $indices->[0]->[0]) {
+                          $mo->{$parameter} = $self->{$parameter};
+                        }
                       }
+                      push(@args, $mo->{$parameter});
                     }
-                    $mo->{$symoid} = $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}->($result->{$fulloid}, $mo->{$parameters});
+                    $mo->{$symoid} = $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}->(@args);
                   } else {
                     $mo->{$symoid} = $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}->($result->{$fulloid});
                   }
@@ -2689,12 +2693,16 @@ sub make_symbolic {
                     exists $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition} &&
                     ref($Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}) eq 'CODE') {
                   if ($parameters) {
-                    if (! exists $mo->{$parameters}) {
-                      if (@{$indices} and scalar(@{$indices}) == 1 and ! $indices->[0]->[0]) {
-                        $mo->{$parameters} = $self->{$parameters};
+                    my @args = ($result->{$fulloid});
+                    foreach my $parameter (split(",", $parameters)) {
+                      if (! exists $mo->{$parameter}) {
+                        if (@{$indices} and scalar(@{$indices}) == 1 and ! $indices->[0]->[0]) {
+                          $mo->{$parameter} = $self->{$parameter};
+                        }
                       }
+                      push(@args, $mo->{$parameter});
                     }
-                    $mo->{$symoid} = $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}->($result->{$fulloid}, $mo->{$parameters});
+                    $mo->{$symoid} = $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}->(@args);
                   } else {
                     $mo->{$symoid} = $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{$mib}->{$definition}->($result->{$fulloid});
                   }

--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/CISCOALARMMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/CISCOALARMMIB.pm
@@ -1,0 +1,56 @@
+package Monitoring::GLPlugin::SNMP::MibsAndOids::CISCOALARMMIB;
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::origin->{'CISCO-ALARM-MIB'} = {
+  url  => 'https://mibs.observium.org/mib/CISCO-ALARM-MIB/',
+  name => 'CISCO-ALARM-MIB'
+};
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::mib_ids->{'CISCO-ALARM-MIB'} = 
+  '1.3.6.1.4.1.9.9.869';
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'CISCO-ALARM-MIB'} = {
+  'coiAlarmActiveTable'                => '1.3.6.1.4.1.9.9.869.1.1.1',
+  'coiAlarmActiveEntry'                => '1.3.6.1.4.1.9.9.869.1.1.1.1',
+  'coiAlarmIndex'                      => '1.3.6.1.4.1.9.9.869.1.1.1.1.1',
+  'coiAlarmServiceAffecting'           => '1.3.6.1.4.1.9.9.869.1.1.1.1.10',
+  'coiAlarmServiceAffectingDefinition' => 'CISCO-ALARM-MIB::coiAlarmServiceAffecting',
+  'coiAlarmDescription'                => '1.3.6.1.4.1.9.9.869.1.1.1.1.11',
+  'coiAlarmObjectIfIndex'              => '1.3.6.1.4.1.9.9.869.1.1.1.1.2',
+  'coiAlarmObjectEntPhyIndex'          => '1.3.6.1.4.1.9.9.869.1.1.1.1.3',
+  'coiAlarmObjectName'                 => '1.3.6.1.4.1.9.9.869.1.1.1.1.4',
+  'coiAlarmObjectType'                 => '1.3.6.1.4.1.9.9.869.1.1.1.1.5',
+  'coiAlarmType'                       => '1.3.6.1.4.1.9.9.869.1.1.1.1.6',
+  'coiAlarmTimeStamp'                  => '1.3.6.1.4.1.9.9.869.1.1.1.1.7',
+  'coiAlarmSeverity'                   => '1.3.6.1.4.1.9.9.869.1.1.1.1.8',
+  'coiAlarmSeverityDefinition'         => 'CISCO-ALARM-MIB::coiAlarmSeverity',
+  'coiAlarmStatus'                     => '1.3.6.1.4.1.9.9.869.1.1.1.1.9',
+  'coiAlarmStatusDefinition'           => 'CISCO-ALARM-MIB::coiAlarmStatus'
+};
+
+$Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{'CISCO-ALARM-MIB'} = {
+  'coiAlarmServiceAffecting' => {
+    '0' => 'unknown',
+    '1' => 'not_service_affecting',
+    '2' => 'service_affecting'
+  },
+  'coiAlarmSeverity' => {
+    '0' => 'unknown',
+    '1' => 'not_reported',
+    '2' => 'not_alarmed',
+    '3' => 'minor',
+    '4' => 'major',
+    '5' => 'critical',
+    '6' => 'severity_last'
+  },
+  'coiAlarmStatus' => {
+    '0' => 'unknown',
+    '1' => 'set',
+    '2' => 'clear',
+    '3' => 'suppress',
+    '4' => 'last'
+  }
+};
+
+1;
+
+__END__

--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/CISCOENTITYSENSORMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/CISCOENTITYSENSORMIB.pm
@@ -21,6 +21,7 @@ $Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'CISCO-ENTITY-SENSOR-M
   'entSensorScaleDefinition' => 'CISCO-ENTITY-SENSOR-MIB::SensorDataScale',
   'entSensorPrecision' => '1.3.6.1.4.1.9.9.91.1.1.1.1.3',
   'entSensorValue' => '1.3.6.1.4.1.9.9.91.1.1.1.1.4',
+  'entSensorValueDefinition' => 'CISCO-ENTITY-SENSOR-MIB::entSensorValue(entSensorScale,entSensorType)',
   'entSensorStatus' => '1.3.6.1.4.1.9.9.91.1.1.1.1.5',
   'entSensorStatusDefinition' => 'CISCO-ENTITY-SENSOR-MIB::SensorStatus',
   'entSensorValueTimeStamp' => '1.3.6.1.4.1.9.9.91.1.1.1.1.6',
@@ -94,6 +95,35 @@ $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{'CISCO-ENTITY-SENSOR-MIB
     '15' => 'peta',
     '16' => 'zetta',
     '17' => 'yotta',
+  },
+  'entSensorValue' => sub {
+    my($value, $scale, $type) = @_;
+    if ($type eq "truthvalue") {
+      return $value ? "true" : "false";
+    } elsif ($type eq "specialEnum") {
+      return $value;
+    } else {
+      my $exp = {
+          yocto => -24,
+          zepto => -21,
+          atto => -18,
+          femto => -15,
+          pico => -12,
+          nano => -9,
+          micro => -6,
+          milli => -3,
+          units => 0,
+          kilo => 3,
+          mega => 6,
+          giga => 9,
+          tera => 12,
+          exa => 15,
+          peta => 18,
+          zetta => 21,
+          yotta => 24,
+      };
+      return exists $exp->{$scale} ? $value * 10 ** $exp->{$scale} : $value;
+    }
   },
 };
 

--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/ENTITYSENSORMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/ENTITYSENSORMIB.pm
@@ -19,6 +19,7 @@ $Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'ENTITY-SENSOR-MIB'} =
   entPhySensorScaleDefinition => 'ENTITY-SENSOR-MIB::EntitySensorDataScale',
   entPhySensorPrecision => '1.3.6.1.2.1.99.1.1.1.3',
   entPhySensorValue => '1.3.6.1.2.1.99.1.1.1.4',
+  #entPhySensorValueDefinition => 'ENTITY-SENSOR-MIB::entPhySensorValue(entPhySensorScale,entPhySensorType)',
   entPhySensorOperStatus => '1.3.6.1.2.1.99.1.1.1.5',
   entPhySensorOperStatusDefinition => 'ENTITY-SENSOR-MIB::EntitySensorStatus',
   entPhySensorUnitsDisplay => '1.3.6.1.2.1.99.1.1.1.6',
@@ -67,5 +68,36 @@ $Monitoring::GLPlugin::SNMP::MibsAndOids::definitions->{'ENTITY-SENSOR-MIB'} = {
     '1' => 'ok',
     '2' => 'unavailable',
     '3' => 'nonoperational',
+  },
+  entPhySensorValue => sub {
+    my($value, $scale, $type) = @_;
+    if ($type eq "truthvalue") {
+      return $value ? "true" : "false";
+    } else {
+      my $exp = {
+# Irgend so ein Hanswurscht bei Cisco hat fuer alle Werte einer ASA
+# entPhySensorScale auf yocto gesetzt.
+# rpm sensor PS0 Fan Sensor reports 5.9e-21rpm
+# Viel ist das nicht. Depp.
+#          yocto => -24,
+          zepto => -21,
+          atto => -18,
+          femto => -15,
+          pico => -12,
+          nano => -9,
+          micro => -6,
+          milli => -3,
+          units => 0,
+          kilo => 3,
+          mega => 6,
+          giga => 9,
+          tera => 12,
+          exa => 15,
+          peta => 18,
+          zetta => 21,
+          yotta => 24,
+      };
+      return exists $exp->{$scale} ? $value * 10 ** $exp->{$scale} : $value;
+    }
   },
 };


### PR DESCRIPTION
This adds support for the [CISCO-ALARM-MIB](https://mibs.observium.org/mib/CISCO-ALARM-MIB/). This has been observed to be supported on **Cisco IOS XR Software (8000), Version 7.3.15.13I-13i_EFT Copyright (c) 2013-2021 by Cisco Systems, Inc.** devices.