### PR TITLE
Add sensorMan OIDs to UPSMIB

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/UPSMIB.pm
+++ b/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/UPSMIB.pm
@@ -156,6 +156,21 @@ $Monitoring::GLPlugin::SNMP::MibsAndOids::mibs_and_oids->{'UPS-MIB'} = {
   upsConfigAudibleStatus => '1.3.6.1.2.1.33.1.9.8.0',
   upsConfigLowVoltageTransferPoint => '1.3.6.1.2.1.33.1.9.9.0',
   upsConfigHighVoltageTransferPoint => '1.3.6.1.2.1.33.1.9.10.0',
+  sensorMan => '1.3.6.1.2.1.33.1.12',
+  sensor1 => '1.3.6.1.2.1.33.1.12.1',
+  sensorMan1Value => '1.3.6.1.2.1.33.1.12.1.1.0',
+  sensorMan1Location => '1.3.6.1.2.1.33.1.12.1.2.0',
+  sensorMan1Unit => '1.3.6.1.2.1.33.1.12.1.3.0',
+  sensorMan1ThresholdLow => '1.3.6.1.2.1.33.1.12.1.4.0',
+  sensorMan1ThresholdHigh => '1.3.6.1.2.1.33.1.12.1.5.0',
+  sensorMan1Offset => '1.3.6.1.2.1.33.1.12.1.7.0',
+  sensor2 => '1.3.6.1.2.1.33.1.12.2',
+  sensorMan2Value => '1.3.6.1.2.1.33.1.12.2.1.0',
+  sensorMan2Location => '1.3.6.1.2.1.33.1.12.2.2.0',
+  sensorMan2Unit => '1.3.6.1.2.1.33.1.12.2.3.0',
+  sensorMan2ThresholdLow => '1.3.6.1.2.1.33.1.12.2.4.0',
+  sensorMan2ThresholdHigh => '1.3.6.1.2.1.33.1.12.2.5.0',
+  sensorMan2Offset => '1.3.6.1.2.1.33.1.12.2.7.0',
 };
 1;
 


### PR DESCRIPTION
This adds support for the sensorMan OIDs which are used as generic sensors for things like temperature and humidity.

Example snmpwalk of the OIDs added:
```
.1.3.6.1.2.1.33.1.12.1.1.0 = INTEGER: 225
.1.3.6.1.2.1.33.1.12.1.2.0 = STRING: "Channel 1"
.1.3.6.1.2.1.33.1.12.1.3.0 = Hex-STRING: C2 B0 43 
.1.3.6.1.2.1.33.1.12.1.4.0 = INTEGER: 50
.1.3.6.1.2.1.33.1.12.1.5.0 = INTEGER: 900
.1.3.6.1.2.1.33.1.12.1.7.0 = INTEGER: 50
.1.3.6.1.2.1.33.1.12.2.1.0 = INTEGER: 210
.1.3.6.1.2.1.33.1.12.2.2.0 = STRING: "Channel 2"
.1.3.6.1.2.1.33.1.12.2.3.0 = STRING: "% rel H"
.1.3.6.1.2.1.33.1.12.2.4.0 = INTEGER: 50
.1.3.6.1.2.1.33.1.12.2.5.0 = INTEGER: 900
.1.3.6.1.2.1.33.1.12.2.7.0 = INTEGER: 50
```

Device Documentation:
https://www.generex.de/media/pages/packages/resources/mib/c71e121b71-1666982011/RFC1628-cs1x1-Overview.pdf
https://www.generex.de/media/pages/packages/resources/mib/d22ebc95e8-1666982011/RFC1628-cs1x1.mib